### PR TITLE
Fix 'GlobalExitRoot' is set as ZeroHash after restart sequencer

### DIFF
--- a/sequencer/finalizer.go
+++ b/sequencer/finalizer.go
@@ -1015,6 +1015,8 @@ func (f *finalizer) syncWithState(ctx context.Context, lastBatchNum *uint64) err
 			return fmt.Errorf("failed to get work-in-progress batch, err: %w", err)
 		}
 	}
+
+	f.lastGERHash = f.batch.globalExitRoot
 	log.Infof("Initial Batch: %+v", f.batch)
 	log.Infof("Initial Batch.StateRoot: %s", f.batch.stateRoot.String())
 	log.Infof("Initial Batch.GER: %s", f.batch.globalExitRoot.String())


### PR DESCRIPTION
Closes #<issue number>.

### What does this PR do?

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

### Reviewers

Main reviewers:

<!-- Main reviewers should do a full review. There should be 2 main reviewers, unless there is a good reason for not to do it -->

- @John
- @Doe

Codeowner reviewers:

<!-- Codeowners should review only the part of code that they own, they're added automatically as reviewers and it's good to let them know that they shouldn't do a full review -->

- @-Alice
- @-Bob
